### PR TITLE
MQTT topics should not use a proceding slash `/`

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ let publishHandler = function (e) {
 // connect to cloud once mqtt is up:
 mClient.on('connect', function () {
     console.log(`${ts()} - mqtt connected`)
-    mClient.publish('/aw/alive', null, publishHandler)
+    mClient.publish('aw/alive', null, publishHandler)
 })
 
 
@@ -49,20 +49,20 @@ api.on('error', e => {
 
 api.on('connect', () => {
     console.log(`${ts()} - connected`)
-    mClient.publish('/aw/connect', null, publishHandler)
+    mClient.publish('aw/connect', null, publishHandler)
     api.subscribe(process.env.API_KEY)
 })
 
 api.on('subscribed', data => {
     console.log(`${ts()} - subscribed`)
-    mClient.publish('/aw/subscribe', JSON.stringify(data))
+    mClient.publish('aw/subscribe', JSON.stringify(data))
     // publish lastdata as data to avoid update interval blackout:
-    mClient.publish('/aw/data', JSON.stringify(data['devices'][0]['lastData']), publishHandler)
+    mClient.publish('aw/data', JSON.stringify(data['devices'][0]['lastData']), publishHandler)
 })
 
 api.on('data', data => {
     console.log(`${ts()} - aw data`)
-    mClient.publish('/aw/data', JSON.stringify(data), publishHandler)
+    mClient.publish('aw/data', JSON.stringify(data), publishHandler)
 })
 
 api.connect()


### PR DESCRIPTION
First off, this is great. I have a PR and I am working on another, I hope that's ok.

I know this can be customized in the .env but should start out with a best practice.

See: https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices

Specifically:
>Never use a leading forward slash
> A leading forward slash is permitted in MQTT. For example, /myhome/groundfloor/livingroom. However, the leading forward slash introduces an unnecessary topic level with a zero character at the front. The zero does not provide any benefit and often leads to confusion.